### PR TITLE
Fix MacBook Air heading capitalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
         <section class=" bg-white h-[500px] bg-center bg-cover sm-macbook md:md-macbook lg:lg-macbook">
             <div>
                 <div class="text-center text-black pt-9 font-sf-pro-display">
-                    <h2 class="text-[32px] min-[832px]:text-[48px] font-semibold tracking-[.004em]">Macbook Air</h2>
+                    <h2 class="text-[32px] min-[832px]:text-[48px] font-semibold tracking-[.004em]">MacBook Air</h2>
                     <h3 class="text-[19px] min-[832px]:text-[24px] mt-1">Lean. Mean. M3 machine.</h3>
                 </div>
                 <div class="text-white mt-3 flex flex-row justify-center text-[17px]">


### PR DESCRIPTION
## Summary
- Capitalize “MacBook Air” heading for consistency with Apple branding.

## Testing
- ⚠️ `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a677cb05cc8327825fc4018774523b