### PR TITLE
Add Jest test for footer toggle behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
+  "scripts": {
+    "test": "jest"
+  },
   "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0",
     "tailwindcss": "^3.4.3"
   }
 }

--- a/src/script.test.js
+++ b/src/script.test.js
@@ -1,0 +1,17 @@
+import { JSDOM } from 'jsdom';
+
+describe('footer list item', () => {
+  test('click toggles active class', () => {
+    const dom = new JSDOM(`<footer><ul><li class="li">Link</li></ul></footer>`);
+    global.document = dom.window.document;
+    global.window = dom.window;
+
+    require('./script.js');
+
+    const item = document.querySelector('.li');
+    item.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+    expect(item.classList.contains('active')).toBe(true);
+    item.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+    expect(item.classList.contains('active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit test verifying footer list item toggles `active` class on click
- define npm test script using Jest and add Jest/Jsdom dev dependencies

## Testing
- `npm test` *(fails: jest not found due to npm install issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a677d93040832795426dafc9e17e83